### PR TITLE
Fix catkin workspace for recursive packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*~
 *.pyc
 doc/tags

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ package.
 Features
 ========
 
-* Sets `&makeprg` to `rosmake <package-name>` so that the package, to which the
-  file being edited belongs, could be built with `:make`.
+* Sets `&makeprg` to `catkin_make` or `rosmake <package-name>` so that the
+package, to which the file being edited belongs, could be built with `:make`.
 * Adds commands:
   - `:A` to alternate between _.cpp_ and _.h_ files in the current package
   - `:Roscd` to cd to an arbitrary ROS package (with tab-completion)


### PR DESCRIPTION
I don't know if there is a clever way to locate the catkin workspace for a specific ROS package.

Anyway, this PR fixes this location for packages not directly under $catkin_workspace/src.
