### PR TITLE
Add compilation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Installation
 
 It is recommended to instal `vim-ros` using [Vundle][] or [pathogen][].
 
+Options
+=======
+
+- `g:ros_make` [current|all] Controls which package to build
+- `g:ros_build_system` [catkin|rosbuild|catkin-tools] Which build system to use
+- `g:ros_catkin_make_options` Additional options for catkin_make (i.e '-j4 -DCMAKE_BUILD_TYPE=Debug' ...)
+
 Contributing
 ============
 

--- a/plugin/ros.vim
+++ b/plugin/ros.vim
@@ -43,6 +43,10 @@ if !exists('g:ros_build_system')
 	let g:ros_build_system = 'catkin'
 endif
 
+if !exists('g:ros_catkin_make_options')
+	let g:ros_catkin_make_options = ''
+endif
+
 " Custom commands have to start with a capital letter in Vim. This means that
 " you will have to type 'Roscd' or 'Rosed' instead of 'roscd' or 'rosed' that
 " your hands are so familiar with. It is possible to have abbreviations for

--- a/plugin/rosvim/__init__.py
+++ b/plugin/rosvim/__init__.py
@@ -41,7 +41,8 @@ def buf_enter():
             catkin_ws = _path[:idx_src]
         else:
             catkin_ws = _path
-        make_cmd = 'catkin_make -C {0} --pkg '.format(catkin_ws)
+        make_cmd = 'catkin_make -C {0} {1} --pkg '.format(catkin_ws,
+                vimp.var['g:ros_catkin_make_options'])
     elif vimp.var['g:ros_build_system'] == 'catkin-tools':
         make_cmd = 'catkin build '
     else:


### PR DESCRIPTION
Hi.
I needed to add some compilation options to catkin_make, which didn't seem supported.
So I added it quickly.

Example

```
let g:ros_build_options = '-DCMAKE_BUILD_TYPE=Debug -j8'
```

Best regards.
Arnaud