### PR TITLE
Added hpp support to alternate() function

### DIFF
--- a/plugin/rosvim/__init__.py
+++ b/plugin/rosvim/__init__.py
@@ -55,7 +55,8 @@ def buf_enter():
 
 # TODO: add 'command' decorator
 def alternate():
-    mapping = {'.h': ('.cpp', '.cc'), '.cpp': ('.h',), '.cc': ('.h',)}
+    mapping = {'.h': ('.cpp', '.cc'), '.cpp': ('.h','.hpp'), '.cc': ('.h',),
+               '.hpp':('.cpp',)}
     if vimp.buf.extension in mapping:
         for altextension in mapping[vimp.buf.extension]:
             altfile = vimp.buf.stem + altextension


### PR DESCRIPTION
This simple change allows the `:A` function to switch back and forth from a header file with extension `hpp`