### PR TITLE
Add split-edit commands. Code refactoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Editor commands
 
 - `:A` to alternate between different kinds of C/C++ files (_.cpp_, _.cc_, _.h_, _.hh_, _.hpp_, _.impl_) in the current package
 - `:Roscd` to cd to an arbitrary ROS package (with tab-completion)
-- `:Rosed`/`:TabRosed` to open arbitrary files (with tab-completion of both
+- `:Rosed`/`:TabRosed`/`:SpRosed`/`:VspRosed` to open arbitrary files (with tab-completion of both
   package and filenames)
 
 Filetype support

--- a/plugin/ros.vim
+++ b/plugin/ros.vim
@@ -125,11 +125,15 @@ augroup END
 command! -nargs=1 -complete=custom,ros#RoscdComplete Roscd :call ros#Roscd(<f-args>)
 command! -nargs=* -complete=custom,ros#RosedComplete Rosed :call ros#Rosed(<f-args>)
 command! -nargs=* -complete=custom,ros#RosedComplete TabRosed :call ros#TabRosed(<f-args>)
+command! -nargs=* -complete=custom,ros#RosedComplete SpRosed :call ros#SpRosed(<f-args>)
+command! -nargs=* -complete=custom,ros#RosedComplete VspRosed :call ros#VspRosed(<f-args>)
 
 if g:ros_lowercase_commands
     cabbrev roscd <c-r>=(getcmdtype()==':' && getcmdpos()==1 ? 'Roscd' : 'roscd')<CR>
     cabbrev rosed <c-r>=(getcmdtype()==':' && getcmdpos()==1 ? 'Rosed' : 'rosed')<CR>
     cabbrev tabrosed <c-r>=(getcmdtype()==':' && getcmdpos()==1 ? 'TabRosed' : 'tabrosed')<CR>
+    cabbrev sprosed <c-r>=(getcmdtype()==':' && getcmdpos()==1 ? 'SpRosed' : 'sprosed')<CR>
+    cabbrev vsprosed <c-r>=(getcmdtype()==':' && getcmdpos()==1 ? 'VspRosed' : 'vsprosed')<CR>
 endif
 
 " }}}

--- a/plugin/rosvim/__init__.py
+++ b/plugin/rosvim/__init__.py
@@ -135,6 +135,46 @@ def tabrosed(package_name, *file_names):
                 vimp.tabedit(f)
 
 
+@vimp.function('ros#SpRosed')
+def sprosed(package_name, *file_names):
+    try:
+        pkg = rosp.Package(package_name)
+    except rospkg.ResourceNotFound:
+        print('Package {0} not found'.format(package_name))
+        return
+    for fn in file_names:
+        files = list(pkg.locate_files(fn))
+        if len(files) == 0:
+            print('File {0} not found'.format(fn))
+        elif len(files) == 1:
+            vimp.split(files[0])
+        else:
+            f = vimp.inputlist('You have chosen a non-unique filename, please '
+                               'pick one of the following:', files)
+            if f is not None:
+                vimp.split(f)
+
+
+@vimp.function('ros#VspRosed')
+def vsprosed(package_name, *file_names):
+    try:
+        pkg = rosp.Package(package_name)
+    except rospkg.ResourceNotFound:
+        print('Package {0} not found'.format(package_name))
+        return
+    for fn in file_names:
+        files = list(pkg.locate_files(fn))
+        if len(files) == 0:
+            print('File {0} not found'.format(fn))
+        elif len(files) == 1:
+            vimp.vsplit(files[0])
+        else:
+            f = vimp.inputlist('You have chosen a non-unique filename, please '
+                               'pick one of the following:', files)
+            if f is not None:
+                vimp.vsplit(f)
+
+
 @vimp.function('ros#RosedComplete')
 def rosed_complete(arg_lead, cmd_line, cursor_pos):
     """

--- a/plugin/rosvim/__init__.py
+++ b/plugin/rosvim/__init__.py
@@ -95,8 +95,15 @@ def roscd_complete(arg_lead, cmd_line, cursor_pos):
     return '\n'.join(sorted(rosp.Package.list()))
 
 
-@vimp.function('ros#Rosed')
-def rosed(package_name, *file_names):
+def _generic_rosed(vim_func, package_name, *file_names):
+    """
+    Helper method to edit a file using a specific `vim_func`.
+
+    Arguments
+    ---------
+    vim_func:
+        Reference to a function defined in the `vimp` module.
+    """
     try:
         pkg = rosp.Package(package_name)
     except rospkg.ResourceNotFound:
@@ -107,72 +114,32 @@ def rosed(package_name, *file_names):
         if len(files) == 0:
             print('File {0} not found'.format(fn))
         elif len(files) == 1:
-            vimp.edit(files[0])
+            vim_func(files[0])
         else:
             f = vimp.inputlist('You have chosen a non-unique filename, please '
                                'pick one of the following:', files)
             if f is not None:
-                vimp.edit(f)
+                vim_func(f)
+
+
+@vimp.function('ros#Rosed')
+def rosed(package_name, *file_names):
+    _generic_rosed(vimp.edit, package_name, *file_names)
 
 
 @vimp.function('ros#TabRosed')
 def tabrosed(package_name, *file_names):
-    try:
-        pkg = rosp.Package(package_name)
-    except rospkg.ResourceNotFound:
-        print('Package {0} not found'.format(package_name))
-        return
-    for fn in file_names:
-        files = list(pkg.locate_files(fn))
-        if len(files) == 0:
-            print('File {0} not found'.format(fn))
-        elif len(files) == 1:
-            vimp.tabedit(files[0])
-        else:
-            f = vimp.inputlist('You have chosen a non-unique filename, please '
-                               'pick one of the following:', files)
-            if f is not None:
-                vimp.tabedit(f)
+    _generic_rosed(vimp.tabedit, package_name, *file_names)
 
 
 @vimp.function('ros#SpRosed')
 def sprosed(package_name, *file_names):
-    try:
-        pkg = rosp.Package(package_name)
-    except rospkg.ResourceNotFound:
-        print('Package {0} not found'.format(package_name))
-        return
-    for fn in file_names:
-        files = list(pkg.locate_files(fn))
-        if len(files) == 0:
-            print('File {0} not found'.format(fn))
-        elif len(files) == 1:
-            vimp.split(files[0])
-        else:
-            f = vimp.inputlist('You have chosen a non-unique filename, please '
-                               'pick one of the following:', files)
-            if f is not None:
-                vimp.split(f)
+    _generic_rosed(vimp.split, package_name, *file_names)
 
 
 @vimp.function('ros#VspRosed')
 def vsprosed(package_name, *file_names):
-    try:
-        pkg = rosp.Package(package_name)
-    except rospkg.ResourceNotFound:
-        print('Package {0} not found'.format(package_name))
-        return
-    for fn in file_names:
-        files = list(pkg.locate_files(fn))
-        if len(files) == 0:
-            print('File {0} not found'.format(fn))
-        elif len(files) == 1:
-            vimp.vsplit(files[0])
-        else:
-            f = vimp.inputlist('You have chosen a non-unique filename, please '
-                               'pick one of the following:', files)
-            if f is not None:
-                vimp.vsplit(f)
+    _generic_rosed(vimp.vsplit, package_name, *file_names)
 
 
 @vimp.function('ros#RosedComplete')

--- a/plugin/vimp/__init__.py
+++ b/plugin/vimp/__init__.py
@@ -67,6 +67,14 @@ def tabedit(filename):
     vim.command('tabedit {0}'.format(filename))
 
 
+def split(filename):
+    vim.command('split {0}'.format(filename))
+
+
+def vsplit(filename):
+    vim.command('vsplit {0}'.format(filename))
+
+
 def lcd(path):
     vim.command('lcd {0}'.format(path))
 


### PR DESCRIPTION
I'm using VIM's split commands quite often, so I added the functionality to vim-ros. This adds two new commands: `:SpRosed` will open a file in horizontal split, and `:VspRosed` will open a file in vertical split, analogous to VIM's `:sp[lit]` and `:vsp[lit]`. 
Furthermore, I wrapped some duplicate code in the `rosvim` module.