### PR TITLE
Run test targets when calling :make from test file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ Options
 - `g:ros_build_system` [catkin|rosbuild|catkin-tools] Which build system to use
 - `g:ros_catkin_make_options` Additional options for catkin_make (i.e '-j4 -DCMAKE_BUILD_TYPE=Debug' ...)
 - `g:ros_catkin_run_tests` Run tests instead of compiling package when test file is in current buffer
-    This will call the target `run_tests_<package_name_of_current_file>_gtest`.
-- `g:ros_test_target_equals_filename` Adds file name without extension to test target
-    This will call the target `run_tests_<package_name_of_current_file>_gtest_<filename_without_extension>`.
+    The value will be used as test target, for example `run_tests` will run all tests.
+    There are some special targets:
+    - `@package` will run all tests of the package of the current file
+    - `@package_gtest` will run all gtests of the package of the current file
+    - `@filename` will call the target `run_tests_<package_name_of_current_file>_gtest_<filename_without_extension>`.
 
 Contributing
 ============

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ Options
 - `g:ros_catkin_run_tests` Run tests instead of compiling package when test file is in current buffer
     The value will be used as test target, for example `run_tests` will run all tests.
     There are some special targets:
-    - `@package` will run all tests of the package of the current file
-    - `@package_gtest` will run all gtests of the package of the current file
-    - `@filename` will call the target `run_tests_<package_name_of_current_file>_gtest_<filename_without_extension>`.
+    - `$package` will run all tests of the package of the current file
+    - `$package_gtest` will run all gtests of the package of the current file
+    - `$filename` will call the target `run_tests_<package_name_of_current_file>_gtest_<filename_without_extension>`.
 
 Contributing
 ============

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Options
 - `g:ros_make` [current|all] Controls which package to build
 - `g:ros_build_system` [catkin|rosbuild|catkin-tools] Which build system to use
 - `g:ros_catkin_make_options` Additional options for catkin_make (i.e '-j4 -DCMAKE_BUILD_TYPE=Debug' ...)
+- `g:ros_catkin_run_tests` Run tests instead of compiling package when test file is in current buffer
+    This will call the target `run_tests_<package_name_of_current_file>_gtest`.
+- `g:ros_test_target_equals_filename` Adds file name without extension to test target
+    This will call the target `run_tests_<package_name_of_current_file>_gtest_<filename_without_extension>`.
 
 Contributing
 ============

--- a/plugin/rosvim/__init__.py
+++ b/plugin/rosvim/__init__.py
@@ -46,22 +46,19 @@ def buf_enter():
             catkin_ws = _path[:idx_src]
         else:
             catkin_ws = _path
-        if 'b:ros_test_target' in vimp.var:
-            make_cmd = 'catkin_make -C {0} {1} {2} --pkg '.format(catkin_ws,
-                    vimp.var['g:ros_catkin_make_options'], vimp.var['b:ros_test_target'])
-        else:
-            make_cmd = 'catkin_make -C {0} {1} --pkg '.format(catkin_ws,
+        make_cmd = 'catkin_make -C {0} {1} '.format(catkin_ws,
                     vimp.var['g:ros_catkin_make_options'])
     elif vimp.var['g:ros_build_system'] == 'catkin-tools':
         make_cmd = 'catkin build '
-        if 'b:ros_test_target' in vimp.var:
-            make_cmd = make_cmd + vimp.var['b:ros_test_target']
     else:
         make_cmd = 'rosmake '
-    if vimp.var['g:ros_make'] == 'all':
-        vimp.opt['makeprg'] = make_cmd + ' '.join(packages.keys())
+    if 'b:ros_test_target' in vimp.var:
+        vimp.opt['makeprg'] = make_cmd + vimp.var['b:ros_test_target']
     else:
-        vimp.opt['makeprg'] = make_cmd + p
+        if vimp.var['g:ros_make'] == 'all':
+            vimp.opt['makeprg'] = make_cmd + ' --pkg ' + ' '.join(packages.keys())
+        else:
+            vimp.opt['makeprg'] = make_cmd + ' --pkg ' + p
 
 
 # TODO: add 'command' decorator

--- a/plugin/rosvim/__init__.py
+++ b/plugin/rosvim/__init__.py
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 from __future__ import print_function
+from string import Template
 
 import vimp
 import rosp
@@ -25,9 +26,10 @@ def buf_init(package_name):
     vimp.var['b:ros_package_path'] = p.path
     vimp.var['b:ros_package_name'] = p.name
     if 'g:ros_catkin_run_tests' in vimp.var and p.name + '/test' in vimp.buf.path:
-        target = 'run_tests_' + p.name + '_gtest'
-        if 'g:ros_test_target_equals_filename' in vimp.var:
-            target = target + '_' + vimp.buf.stem
+        template = Template(vimp.var['g:ros_catkin_run_tests'])
+        target = template.substitute(package='run_tests_'+p.name,
+                package_gtest='run_tests_'+p.name+'_gtest',
+                filename='run_tests_'+p.name+'_gtest'+'_'+vimp.buf.stem)
         vimp.var['b:ros_test_target'] = target
     if p.name not in packages:
         packages[p.name] = p

--- a/plugin/rosvim/__init__.py
+++ b/plugin/rosvim/__init__.py
@@ -24,6 +24,11 @@ def buf_init(package_name):
         return
     vimp.var['b:ros_package_path'] = p.path
     vimp.var['b:ros_package_name'] = p.name
+    if 'g:ros_catkin_run_tests' in vimp.var and p.name + '/test' in vimp.buf.path:
+        target = 'run_tests_' + p.name + '_gtest'
+        if 'g:ros_test_target_equals_filename' in vimp.var:
+            target = target + '_' + vimp.buf.stem
+        vimp.var['b:ros_test_target'] = target
     if p.name not in packages:
         packages[p.name] = p
     ft.init()
@@ -41,10 +46,16 @@ def buf_enter():
             catkin_ws = _path[:idx_src]
         else:
             catkin_ws = _path
-        make_cmd = 'catkin_make -C {0} {1} --pkg '.format(catkin_ws,
-                vimp.var['g:ros_catkin_make_options'])
+        if 'b:ros_test_target' in vimp.var:
+            make_cmd = 'catkin_make -C {0} {1} {2} --pkg '.format(catkin_ws,
+                    vimp.var['g:ros_catkin_make_options'], vimp.var['b:ros_test_target'])
+        else:
+            make_cmd = 'catkin_make -C {0} {1} --pkg '.format(catkin_ws,
+                    vimp.var['g:ros_catkin_make_options'])
     elif vimp.var['g:ros_build_system'] == 'catkin-tools':
         make_cmd = 'catkin build '
+        if 'b:ros_test_target' in vimp.var:
+            make_cmd = make_cmd + vimp.var['b:ros_test_target']
     else:
         make_cmd = 'rosmake '
     if vimp.var['g:ros_make'] == 'all':


### PR DESCRIPTION
When editing a test file and calling :make, this pull request allows to run a test target instead of compiling the package, which does not compile the current file.

This feature has to be activated by setting `g:ros_catkin_run_tests`. The target to run can be set to any target, for example `run_tests` will run all test inside the workspace. There are 3 special targets:

- `$package` will run all tests of the package of the current file
- `$package_gtest` will run all gtests of the package of the current file
- `$filename` will call the target run_tests_<package_name_of_current_file>_gtest_<filename_without_extension>`.