### PR TITLE
ignore clangd index directory

### DIFF
--- a/plugin/rosp/package.py
+++ b/plugin/rosp/package.py
@@ -45,7 +45,7 @@ class Package(object):
             Controls how the function outputs found files, whether absolute
             paths or just filenames.
         """
-        exclude = ['.git', '.hg', '.svn', 'bin', 'build', 'lib']
+        exclude = ['.git', '.hg', '.svn', 'bin', 'build', 'lib', '.clangd']
         for path, dirs, files in os.walk(os.path.abspath(self._path)):
             for d in exclude:
                 if d in dirs:


### PR DESCRIPTION
clangd will create `.clangd` directories if it's used with  `--background-index`, which then show up in `:rosed`. This removes them from the list.